### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # redux-react-firebase
 Use Firebase with React and Redux in ES6
 
+**WARNING: This package is compatible with versions 1.x.x and 2.x.x of the Firebase SDK. If you are using the 3.x.x SDK, please refer to [here](https://github.com/prescottprue/redux-firebasev3).**
+
 ## Features
 - Integrated into redux
 - Support small data ( using `value` ) or large datasets ( using `child_added`, `child_removed`, `child_changed`
@@ -85,10 +87,6 @@ See [API](API.md)
 
 ## Example
 You can see a complete example [here](example)
-
-## In the future
-- Add support for new  Firebase version ( lib ver 3.x )
-- Ideas are welcome :)
 
 ## Contributors
 - [Tiberiu Craciun](https://github.com/tiberiuc)


### PR DESCRIPTION
@tiberiuc because the new sdk is not backward compatibility i think it will be good to keep this repo for the users that still use the old sdk, and refer new users to the new repo that support the new sdk.
Or it will be better to merge between the repos with 2 separate branches to save the original repo.
