### PR TITLE
Update package.json to point to build directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-react-firebase",
   "version": "2.2.2",
   "description": "Use Firebase with React and Redux in ES6 ",
-  "main": "source/index.js",
+  "main": "build/index.js",
   "scripts": {
     "build": "babel source --out-dir build",
     "build-dev": "babel source --out-dir build --watch --source-maps inline",


### PR DESCRIPTION
Currently the package.json points to /source instead of /build. This can cause errors if you ignore node_modules within babel as you'll receive an error on a import statement.
