### PR TITLE
Logout does not (have to) remove all the data

### DIFF
--- a/API.md
+++ b/API.md
@@ -190,8 +190,10 @@ Always authenticate the new user in case of success
 #### Return
 Return a promise with authData in case of success or the error otherwise.
 
-### `logout()`
-Logout from Firebase and delete all data from the store (`store.state.firebase.data`).
+### `logout(preserve = [], remove = [])`
+Logout from Firebase and delete data from the store (`store.state.firebase.data`) except for paths defined in the `preserve` array argument.
+If you want to delete some parts of the preserved subtrees, you can specify the paths in the `remove` argument. Both of these arguments are
+optional and are empty arrays by default. If you do not specify them, all the data is deleted. 
 
 `store.state.firebase.auth` is set to `null`
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ See [API](API.md)
 ## Example
 You can see a complete example [here](example)
 
+## Tests
+Mocha.js is used as test runner. To run the tests, run
+
+```
+npm run test
+```
+
 ## Contributors
 - [Tiberiu Craciun](https://github.com/tiberiuc)
 - [Rahav Lussto](https://github.com/RahavLussato)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepublish": "npm run clean && npm run build",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "author": "Tiberiu Craciun <tibi@happysoft.ro>",
   "license": "MIT",
@@ -49,13 +49,16 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.3.13",
+    "babel-register": "^6.16.3",
+    "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "eslint-config-standard": "^5.3.1",
     "eslint-config-standard-react": "^2.5.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-react": "^5.2.2",
-    "eslint-plugin-standard": "^1.3.2"
+    "eslint-plugin-standard": "^1.3.2",
+    "mocha": "^3.1.0"
   },
   "npmName": "redux-react-firebase",
   "npmFileMap": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-preset-stage-1": "^6.3.13",
     "babel-register": "^6.16.3",
     "chai": "^3.5.0",
+    "chai-spies": "^0.7.1",
     "eslint": "^2.13.1",
     "eslint-config-standard": "^5.3.1",
     "eslint-config-standard-react": "^2.5.0",

--- a/source/actions.js
+++ b/source/actions.js
@@ -252,9 +252,9 @@ export const init = (dispatch, firebase) => {
   firebase.auth().currentUser
 }
 
-export const logout = (dispatch, firebase) => {
+export const logout = (dispatch, firebase, preserve = [], remove = []) => {
   firebase.auth().signOut()
-  dispatch({type: LOGOUT})
+  dispatch({type: LOGOUT, preserve, remove})
   firebase._.authUid = null
   unWatchUserProfile(firebase)
 }
@@ -291,7 +291,7 @@ export const resetPassword = (dispatch, firebase, email) => {
       }
       return
     }
-  });
+  })
 }
 
 export default { watchEvents, unWatchEvents, init, logout, createUser, resetPassword }

--- a/source/compose.js
+++ b/source/compose.js
@@ -29,8 +29,7 @@ export default (config) => {
       writable: true,
       enumerable: true,
       configurable: true
-    });
-
+    })
 
     const set = (path, value, onComplete) => ref.child(path).set(value, onComplete)
     const push = (path, value, onComplete) => ref.child(path).push(value, onComplete)
@@ -39,7 +38,7 @@ export default (config) => {
     const watchEvent = (eventName, eventPath) => Actions.watchEvent(firebase, dispatch, eventName, eventPath, true)
     const unWatchEvent = (eventName, eventPath, queryId = undefined) => Actions.unWatchEvent(firebase, eventName, eventPath, queryId)
     const login = credentials => Actions.login(dispatch, firebase, credentials)
-    const logout = () => Actions.logout(dispatch, firebase)
+    const logout = (preserve = [], remove = []) => Actions.logout(dispatch, firebase, preserve, remove)
     const createUser = (credentials, profile) => Actions.createUser(dispatch, firebase, credentials, profile)
     const resetPassword = (credentials) => Actions.resetPassword(dispatch, firebase, credentials)
     const changePassword = (credentials) => Actions.changePassword(dispatch, firebase, credentials)

--- a/test/actions/logout-test.js
+++ b/test/actions/logout-test.js
@@ -1,0 +1,60 @@
+/* global describe, it */
+import chai from 'chai'
+import spies from 'chai-spies'
+chai.use(spies)
+const { expect } = chai
+
+import { logout } from '../../source/actions'
+import { LOGOUT } from '../../source/constants'
+
+const createFirebaseMock = (signOutSpy = () => {}) => ({
+  auth: () => ({ signOut: signOutSpy }),
+  _: {
+    authUid: '123',
+    config: {
+      userProfile: 'xyz'
+    }
+  }
+})
+
+describe('actions - dispatch logout', () => {
+  it('must dispatch logout action and manipulate firebase', () => {
+    const dispatchSpy = chai.spy()
+    const signOut = chai.spy()
+    const firebaseMock = {
+      auth: () => ({ signOut }),
+      _: {
+        authUid: '123',
+        config: {
+          userProfile: 'xyz'
+        }
+      }
+    }
+
+    logout(dispatchSpy, firebaseMock)
+    expect(signOut).to.have.been.called.once()
+    expect(dispatchSpy).to.have.been.called.once()
+    expect(dispatchSpy).to.have.been.called.with({type: LOGOUT, preserve: [], remove: []})
+  })
+
+  it('must dispatch logout action with preserve param', () => {
+    const dispatchSpy = chai.spy()
+    const firebaseMock = createFirebaseMock()
+    const preserve = ['A', 'B/C', 'D']
+
+    logout(dispatchSpy, firebaseMock, preserve)
+    expect(dispatchSpy).to.have.been.called.once()
+    expect(dispatchSpy).to.have.been.called.with({type: LOGOUT, preserve, remove: []})
+  })
+
+  it('must dispatch logout action with preserve and remove params', () => {
+    const dispatchSpy = chai.spy()
+    const firebaseMock = createFirebaseMock()
+    const preserve = ['A', 'B/C', 'D']
+    const remove = ['X', 'A/B', 'F']
+
+    logout(dispatchSpy, firebaseMock, preserve, remove)
+    expect(dispatchSpy).to.have.been.called.once()
+    expect(dispatchSpy).to.have.been.called.with({type: LOGOUT, preserve, remove})
+  })
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--compilers js:babel-register
+--recursive
+--timeout 2000

--- a/test/reducer/logout-test.js
+++ b/test/reducer/logout-test.js
@@ -1,0 +1,71 @@
+/* global describe, it */
+import { expect } from 'chai'
+
+import reducer from '../../source/reducer'
+import { SET, LOGOUT } from '../../source/constants'
+import { Map } from 'immutable'
+
+describe('reducer - handle logout', () => {
+  it('must restore initial state when no action payload is specified', () => {
+    let state = reducer(undefined, {})
+    state = reducer(state, {type: SET, path: 'foo', data: 'bar', snapshot: 'bar'})
+    state = reducer(state, {type: LOGOUT})
+
+    // state must be reset
+    expect(state.get('auth')).to.equal(null)
+    expect(state.get('authError')).to.equal(null)
+    expect(state.get('profile')).to.equal(null)
+    expect(state.get('data')).to.be.instanceOf(Map)
+    expect(state.get('data').size).to.equal(0)
+    expect(state.get('snapshot')).to.be.instanceOf(Map)
+    expect(state.get('snapshot').size).to.equal(0)
+  })
+
+  it('must preserve some parts of the data and snapshot tree', () => {
+    let state = reducer(undefined, {})
+    state = reducer(state, {type: SET, path: 'foo', data: 'X', snapshot: 'X'})
+    state = reducer(state, {type: SET, path: 'bar', data: 'Y', snapshot: 'Y'})
+    state = reducer(state, {type: LOGOUT, preserve: ['foo']})
+
+    // state must be reset but not everything must be deleted
+    expect(state.get('auth')).to.equal(null)
+    expect(state.get('authError')).to.equal(null)
+    expect(state.get('profile')).to.equal(null)
+    expect(state.get('data')).to.be.instanceOf(Map)
+    expect(state.get('data').size).to.equal(1)
+    expect(state.getIn(['data', 'foo'])).to.equal('X')
+    expect(state.get('snapshot')).to.be.instanceOf(Map)
+    expect(state.get('snapshot').size).to.equal(1)
+    expect(state.getIn(['snapshot', 'foo'])).to.equal('X')
+  })
+
+  it('must preserve some parts of the data and snapshot tree and remove some other', () => {
+    let state = reducer(undefined, {})
+    state = reducer(state, {type: SET, path: 'foo/X', data: 'Y', snapshot: 'Y'})
+    state = reducer(state, {type: SET, path: 'foo/A', data: 'B', snapshot: 'B'})
+    state = reducer(state, {type: LOGOUT, preserve: ['foo'], remove: ['foo/A']})
+
+    // state must be reset but not everything must be deleted
+    expect(state.getIn(['data', 'foo']).size).to.equal(1)
+    expect(state.getIn(['data', 'foo', 'X'])).to.equal('Y')
+    expect(state.getIn(['snapshot', 'foo']).size).to.equal(1)
+    expect(state.getIn(['snapshot', 'foo', 'X'])).to.equal('Y')
+  })
+
+  it('must not create paths which did not exist in the old state when preserving', () => {
+    let state = reducer(undefined, {})
+    state = reducer(state, {type: LOGOUT, preserve: ['foo']})
+
+    // state must be reset but not everything must be deleted
+    expect(state.get('data').size).to.equal(0)
+  })
+
+  it('must not create paths which did not exist in the old state when removing', () => {
+    let state = reducer(undefined, {})
+    state = reducer(state, {type: SET, path: 'foo/X', data: 'Y', snapshot: 'Y'})
+    state = reducer(state, {type: LOGOUT, remove: ['foo']})
+
+    // state must be reset but not everything must be deleted
+    expect(state.get('data').size).to.equal(0)
+  })
+})


### PR DESCRIPTION
Logout action removes all the stored data from firebase - even the data, which is public and does not require authentication, as discussed in #31.

This pull request gives the user of this library to preserve parts of the database data he/she does not want to be erased from the local state.

The approach of this pull request is backwards compatible (no params => delete whole state) and adds several unit tests (using Mocha, Chai) to proove the functionality. The API.md and README.md documentation files are updated to reflect the changes too.
