### PR TITLE
Dispatch Login Error on login error.

### DIFF
--- a/source/actions.js
+++ b/source/actions.js
@@ -233,7 +233,12 @@ export const login = (dispatch, firebase, credentials) => {
     dispatchLoginError(dispatch, null)
 
     const {email, password} = credentials
-    firebase.auth().signInWithEmailAndPassword(email, password).then(resolve).catch(reject);
+    firebase.auth().signInWithEmailAndPassword(email, password)
+      .then(resolve)
+      .catch(err => {
+        dispatchLoginError(dispatch, err)
+        reject(err)
+      });
   })
 }
 


### PR DESCRIPTION
On logging in with incorrect details `dispatchLoginError` was not called as it was in other actions.
