### PR TITLE
Fix inner array comparison in `isEqualArrays`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-react-firebase",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Use Firebase with React and Redux in ES6 ",
   "main": "build/index.js",
   "scripts": {

--- a/source/connect.js
+++ b/source/connect.js
@@ -8,7 +8,11 @@ const defaultEvent = {
 
 const fixPath = (path) =>  ((path.substring(0,1) == '/') ? '': '/') + path
 
-const isEqualArrays = (a, b) => a.length == b.length && a.every((v,i) => v === b[i])
+const isEqualArrays = (a, b) => a.length == b.length && a.every((v,i) => {
+  const v1 = typeof v === 'string' ? v : v[0];
+  const v2 = typeof b[i] === 'string' ? b[i] : b[i][0];
+  return v1 === v2;
+})
 
 const ensureCallable = maybeFn =>
   typeof maybeFn === 'function' ? maybeFn : _ => maybeFn


### PR DESCRIPTION
Given a watch query that contains array of array such as:

```js
const fbWrappedComponent = firebase(({params}) => [
    [`/entry/byChannel/${params.channel}`]
  ])(SiteChat);
```

creates an infinite loop, because `isEqualArrays` makes a shallow
comparison of the keys, ignoring inner arrays.

After this PR inner comparison is array-aware.