### PR TITLE
Move Babel plugins and presets to the NPM scripts and delete .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": ["es2015", "stage-1", "react"],
-  "plugins": [
-    ["transform-decorators-legacy", "lodash"]
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Use Firebase with React and Redux in ES6 ",
   "main": "build/index.js",
   "scripts": {
-    "build": "babel source --out-dir build",
-    "build-dev": "babel source --out-dir build --watch --source-maps inline",
+    "build": "babel --plugins transform-decorators-legacy,lodash --presets es2015,stage-1,react source --out-dir build",
+    "build-dev": "babel --plugins transform-decorators-legacy,lodash --presets es2015,stage-1,react source --out-dir build --watch --source-maps inline",
     "watch": "npm run build -- --watch",
     "clean": "rimraf build",
     "prepublish": "npm run clean && npm run build",


### PR DESCRIPTION
Babel plugins and presets in package.json so .babelrc can bet omitted. The .babelrc may cause problems with React Native for it contains it's own Babel configuration. Removing the .babelrc file and placing the Babel plugins and presets directly in the babel command makes it possible to use this library with React Native
